### PR TITLE
 Conditional jump in function AddClient() from pollmanager FIXED

### DIFF
--- a/sources/core/PollManager.cpp
+++ b/sources/core/PollManager.cpp
@@ -66,6 +66,7 @@ void PollManager::pollLoop(int server_fd, std::vector<int> &newClients, std::vec
 void PollManager::addClient(short unsigned fd)
 {
     struct pollfd pfd;
+    std::memset(&pfd, 0, sizeof(pfd));
     pfd.fd = fd;
     pfd.events = POLLIN;
     _fds.push_back(pfd);


### PR DESCRIPTION
# Pull Request – Fix Conditional Jump in PollManager::addClient()

## Summary

This pull request fixes a **Valgrind-reported issue** in the `PollManager::addClient()` function, where a conditional jump depended on an **uninitialized value**. The root cause was that the `pollfd.revents` field was not explicitly initialized before being used inside the `pollLoop()` logic.

## Issue

- **Valgrind error**: